### PR TITLE
Migrating all upbound references to crossplane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Setup Project
 
 PROJECT_NAME := provider-jet-vault
-PROJECT_REPO := github.com/upbound/$(PROJECT_NAME)
+PROJECT_REPO := github.com/crossplane-contrib/$(PROJECT_NAME)
 
 export TERRAFORM_VERSION := 1.1.6
 
@@ -50,7 +50,7 @@ GO111MODULE = on
 # ====================================================================================
 # Setup Images
 
-REGISTRY_ORGS ?= docker.io/upbound
+REGISTRY_ORGS ?= docker.io/crossplane
 IMAGES = provider-jet-vault provider-jet-vault-controller
 -include build/makelib/imagelight.mk
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ Vault API.
 ## Getting Started
 
 Install the provider by using the following command after changing the image tag
-to the [latest release](https://github.com/upbound/provider-jet-vault/releases):
+to the [latest release](https://github.com/crossplane-contrib/provider-jet-vault/releases):
 ```
 kubectl crossplane install provider crossplane/provider-jet-vault:v0.1.0
 ```
 
-You can see the API reference [here](https://doc.crds.dev/github.com/upbound/provider-jet-vault).
+You can see the API reference [here](https://doc.crds.dev/github.com/crossplane-contrib/provider-jet-vault).
 
 ## Developing
 
@@ -55,7 +55,7 @@ make build
 ## Report a Bug
 
 For filing bugs, suggesting improvements, or requesting new features, please
-open an [issue](https://github.com/upbound/provider-jet-vault/issues).
+open an [issue](https://github.com/crossplane-contrib/provider-jet-vault/issues).
 
 ## Contact
 

--- a/apis/zz_register.go
+++ b/apis/zz_register.go
@@ -22,8 +22,8 @@ package apis
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 
-	v1alpha1 "github.com/upbound/provider-jet-vault/apis/generic/v1alpha1"
-	v1alpha1apis "github.com/upbound/provider-jet-vault/apis/v1alpha1"
+	v1alpha1 "github.com/crossplane-contrib/provider-jet-vault/apis/generic/v1alpha1"
+	v1alpha1apis "github.com/crossplane-contrib/provider-jet-vault/apis/v1alpha1"
 )
 
 func init() {

--- a/cmd/generator/main.go
+++ b/cmd/generator/main.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/crossplane/terrajet/pkg/pipeline"
 
-	"github.com/upbound/provider-jet-vault/config"
+	"github.com/crossplane-contrib/provider-jet-vault/config"
 )
 
 func main() {

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -33,10 +33,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	"github.com/upbound/provider-jet-vault/apis"
-	"github.com/upbound/provider-jet-vault/config"
-	"github.com/upbound/provider-jet-vault/internal/clients"
-	"github.com/upbound/provider-jet-vault/internal/controller"
+	"github.com/crossplane-contrib/provider-jet-vault/apis"
+	"github.com/crossplane-contrib/provider-jet-vault/config"
+	"github.com/crossplane-contrib/provider-jet-vault/internal/clients"
+	"github.com/crossplane-contrib/provider-jet-vault/internal/controller"
 )
 
 func main() {

--- a/config/provider.go
+++ b/config/provider.go
@@ -23,12 +23,12 @@ import (
 	tjconfig "github.com/crossplane/terrajet/pkg/config"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/upbound/provider-jet-vault/config/generic"
+	"github.com/crossplane-contrib/provider-jet-vault/config/generic"
 )
 
 const (
 	resourcePrefix = "vault"
-	modulePath     = "github.com/upbound/provider-jet-vault"
+	modulePath     = "github.com/crossplane-contrib/provider-jet-vault"
 )
 
 //go:embed schema.json

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
-module github.com/upbound/provider-jet-vault
+module github.com/crossplane-contrib/provider-jet-vault
 
 go 1.17
 
 require (
 	github.com/crossplane/crossplane-runtime v0.15.1-0.20220106140106-428b7c390375
 	github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e
-	github.com/crossplane/terrajet v0.4.0
+	github.com/crossplane/terrajet v0.4.2
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/pkg/errors v0.9.1
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/crossplane/crossplane-runtime v0.15.1-0.20220106140106-428b7c390375 h
 github.com/crossplane/crossplane-runtime v0.15.1-0.20220106140106-428b7c390375/go.mod h1:CH05KIlxoEHEE4aLpUhPuvF+9qXsN6/H6YIDnUEjlDs=
 github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e h1:7UM4E9gNEzJ22JgRZqY2KBlkdMCAiHmKS96rcLANdME=
 github.com/crossplane/crossplane-tools v0.0.0-20210916125540-071de511ae8e/go.mod h1:3GzY5sP0PVePArghBh5K4fGzS/3kM0R/NAZn5s7LXqw=
-github.com/crossplane/terrajet v0.4.0 h1:1EwVGb4V88VPqU35GnWbjcvFQD4yqJ+llZxdCbKkAnk=
-github.com/crossplane/terrajet v0.4.0/go.mod h1:oynNx4au8y/tiSb1OanWSMmUf55Cz/O4f1HxH+liI2A=
+github.com/crossplane/terrajet v0.4.2 h1:tWgjjPDwzwlurRYgaujsXL7NHhehBy1C8PZloTUQ65U=
+github.com/crossplane/terrajet v0.4.2/go.mod h1:oynNx4au8y/tiSb1OanWSMmUf55Cz/O4f1HxH+liI2A=
 github.com/dave/jennifer v1.4.1 h1:XyqG6cn5RQsTj3qlWQTKlRGAyrTcsk1kUmWdZBzRjDw=
 github.com/dave/jennifer v1.4.1/go.mod h1:7jEdnm+qBcxl8PC0zyp7vxcpSRnzXSt9r39tpTVGlwA=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/clients/vault.go
+++ b/internal/clients/vault.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/upbound/provider-jet-vault/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-jet-vault/apis/v1alpha1"
 )
 
 const (

--- a/internal/controller/generic/secret/zz_controller.go
+++ b/internal/controller/generic/secret/zz_controller.go
@@ -29,7 +29,7 @@ import (
 	"github.com/crossplane/terrajet/pkg/terraform"
 	ctrl "sigs.k8s.io/controller-runtime"
 
-	v1alpha1 "github.com/upbound/provider-jet-vault/apis/generic/v1alpha1"
+	v1alpha1 "github.com/crossplane-contrib/provider-jet-vault/apis/generic/v1alpha1"
 )
 
 // Setup adds a controller that reconciles Secret managed resources.

--- a/internal/controller/providerconfig/config.go
+++ b/internal/controller/providerconfig/config.go
@@ -25,7 +25,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/crossplane/terrajet/pkg/controller"
 
-	"github.com/upbound/provider-jet-vault/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-jet-vault/apis/v1alpha1"
 )
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for

--- a/internal/controller/zz_setup.go
+++ b/internal/controller/zz_setup.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/crossplane/terrajet/pkg/controller"
 
-	secret "github.com/upbound/provider-jet-vault/internal/controller/generic/secret"
-	providerconfig "github.com/upbound/provider-jet-vault/internal/controller/providerconfig"
+	secret "github.com/crossplane-contrib/provider-jet-vault/internal/controller/generic/secret"
+	providerconfig "github.com/crossplane-contrib/provider-jet-vault/internal/controller/providerconfig"
 )
 
 // Setup creates all controllers with the supplied logger and adds them to

--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -4,4 +4,4 @@ metadata:
   name: provider-jet-vault
 spec:
   controller:
-    image: upbound/provider-jet-vault-controller:VERSION
+    image: crossplane/provider-jet-vault-controller:VERSION


### PR DESCRIPTION
### Description of your changes

This project is now hosted under the crossplane-contrib organization. Updating all `upbound` references to crossplane.

Fixes #

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Ran `make reviewable`
Created a secret in a vault running in same (kind) cluster.
[contribution process]: https://git.io/fj2m9
