### PR TITLE
Using TARGETARCH to capture arch-appropriate terraform binaries

### DIFF
--- a/cluster/images/provider-jet-vault-controller/Dockerfile
+++ b/cluster/images/provider-jet-vault-controller/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.13
 RUN apk --no-cache add ca-certificates bash
 
-ARG ARCH
+ARG TARGETOS
+ARG TARGETARCH
 ARG TINI_VERSION
 ENV USER_ID=1001
 
@@ -15,27 +16,27 @@ ARG TERRAFORM_PROVIDER_DOWNLOAD_NAME
 ARG TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX
 ## End of - Provider-dependent configuration
 
-ENV PLUGIN_DIR /terraform/provider-mirror/registry.terraform.io/${TERRAFORM_PROVIDER_SOURCE}/${TERRAFORM_PROVIDER_VERSION}/linux_${ARCH}
+ENV PLUGIN_DIR /terraform/provider-mirror/registry.terraform.io/${TERRAFORM_PROVIDER_SOURCE}/${TERRAFORM_PROVIDER_VERSION}/linux_${TARGETARCH}
 ENV TF_CLI_CONFIG_FILE /terraform/.terraformrc
 ENV TF_FORK 0
 
 RUN mkdir -p ${PLUGIN_DIR}
 
-ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip /tmp
-ADD ${TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX}/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_linux_${ARCH}.zip /tmp
+ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip /tmp
+ADD ${TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX}/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_linux_${TARGETARCH}.zip /tmp
 
 ADD terraformrc.hcl ${TF_CLI_CONFIG_FILE}
 
-RUN unzip /tmp/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip -d /usr/local/bin \
+RUN unzip /tmp/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip -d /usr/local/bin \
   && chmod +x /usr/local/bin/terraform \
-  && rm /tmp/terraform_${TERRAFORM_VERSION}_linux_${ARCH}.zip \
-  && unzip /tmp/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_linux_${ARCH}.zip -d ${PLUGIN_DIR} \
+  && rm /tmp/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip \
+  && unzip /tmp/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_linux_${TARGETARCH}.zip -d ${PLUGIN_DIR} \
   && chmod +x ${PLUGIN_DIR}/* \
-  && rm /tmp/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_linux_${ARCH}.zip \
+  && rm /tmp/${TERRAFORM_PROVIDER_DOWNLOAD_NAME}_${TERRAFORM_PROVIDER_VERSION}_linux_${TARGETARCH}.zip \
   && chown -R ${USER_ID}:${USER_ID} /terraform
 # End of - Setup Terraform environment
 
-ADD provider /usr/local/bin/crossplane-provider
+ADD bin/$TARGETOS\_$TARGETARCH/provider /usr/local/bin/crossplane-provider
 
 # Provider controller needs these environment variable at runtime
 ENV TERRAFORM_VERSION ${TERRAFORM_VERSION}

--- a/cluster/images/provider-jet-vault-controller/Makefile
+++ b/cluster/images/provider-jet-vault-controller/Makefile
@@ -24,11 +24,11 @@ img.publish:
 img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cp terraformrc.hcl $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cp $(OUTPUT_DIR)/bin/$(OS)_$(ARCH)/provider $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cp $(OUTPUT_DIR)/bin/$(OS)_$(TARGETARCH)/provider $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@docker buildx build $(BUILD_ARGS) \
 		--platform $(IMAGE_PLATFORMS) \
-		--build-arg ARCH=$(ARCH) \
+		--build-arg ARCH=$(TARGETARCH) \
 		--build-arg TINI_VERSION=$(TINI_VERSION) \
 		--build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) \
 		--build-arg TERRAFORM_PROVIDER_SOURCE=$(TERRAFORM_PROVIDER_SOURCE) \

--- a/cluster/images/provider-jet-vault-controller/Makefile
+++ b/cluster/images/provider-jet-vault-controller/Makefile
@@ -24,11 +24,10 @@ img.publish:
 img.build.shared:
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cp terraformrc.hcl $(IMAGE_TEMP_DIR) || $(FAIL)
-	@cp $(OUTPUT_DIR)/bin/$(OS)_$(TARGETARCH)/provider $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cp -r $(OUTPUT_DIR)/bin/ $(IMAGE_TEMP_DIR)/bin || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && $(SED_CMD) 's|BASEIMAGE|$(OSBASEIMAGE)|g' Dockerfile || $(FAIL)
 	@docker buildx build $(BUILD_ARGS) \
 		--platform $(IMAGE_PLATFORMS) \
-		--build-arg ARCH=$(TARGETARCH) \
 		--build-arg TINI_VERSION=$(TINI_VERSION) \
 		--build-arg TERRAFORM_VERSION=$(TERRAFORM_VERSION) \
 		--build-arg TERRAFORM_PROVIDER_SOURCE=$(TERRAFORM_PROVIDER_SOURCE) \


### PR DESCRIPTION
### Description of your changes

We are seeing errors running builds on Mac M1 machines. Investigating the builds on dockerhub we see that both the arm and amd images are pulling amd binaries.

Setting ARCH Build Arg from TARGETARCH to get proper binaries in each image.

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Built locally to confirm the change is non-breaking.

[contribution process]: https://git.io/fj2m9
